### PR TITLE
Fix deprecation warning in module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,4 +1,5 @@
 {
+  "id": "fvtt-party-resources",
   "name": "fvtt-party-resources",
   "title": "Party Resources",
   "description": "Create and track custom party resources.",

--- a/module.json
+++ b/module.json
@@ -6,6 +6,10 @@
   "authors": [
     {
       "name": "Dave Lens"
+    },
+    {
+      "name": "Kit",
+      "discord": "wlonk#6479"
     }
   ],
   "url": "https://github.com/davelens/fvtt-party-resources",


### PR DESCRIPTION
This resolves a deprecation warning caused by using the "name" key rather than the "id" key.

As an offering, I give you this baby rhino:

![baby rhino](https://www.zooborns.com/.a/6a010535647bf3970b02b751722eee200b-800wi)