### PR TITLE
Debounce re-rendering caused by document updates

### DIFF
--- a/src/init.mjs
+++ b/src/init.mjs
@@ -35,6 +35,11 @@ Hooks.once('ready', () => {
   ResourcesStatusBar.render()
 })
 
+const render_resources = foundry.utils.debounce(() => {
+  window.pr.dashboard.redraw()
+  window.pr.status_bar.render()
+}, 25)
+
 // Because system-specific totals need to be updated as currency or item totals
 // get modified.
 Hooks.on('createItem', render_resources)
@@ -86,9 +91,4 @@ function templates() {
     'modules/fvtt-party-resources/src/views/dashboard_button.html',
     'modules/fvtt-party-resources/src/views/status_bar.html'
   ]
-}
-
-function render_resources() {
-  window.pr.dashboard.redraw()
-  window.pr.status_bar.render()
 }


### PR DESCRIPTION
This attempts to improve performance in situations where a batched operation occurs, such as the bless aura in pf2e.

I am aware that re-renders due to document updates are a thing that only matters in 5e, though I don't know of a batched document update example there since I don't play that system.
